### PR TITLE
Update mempool-replacements.md

### DIFF
--- a/doc/policy/mempool-replacements.md
+++ b/doc/policy/mempool-replacements.md
@@ -17,7 +17,7 @@ other consensus and policy rules, each of the following conditions are met:
    *Rationale*: See [BIP125
    explanation](https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki#motivation).
 
-2. The replacement transaction only include an unconfirmed input if that input was included in
+2. The replacement transaction only includes an unconfirmed input if that input was included in
    one of the directly conflicting transactions. An unconfirmed input spends an output from a
    currently-unconfirmed transaction.
 


### PR DESCRIPTION
### Corrected grammatical error in the following sentence:

**Error:** "The replacement transaction only include an unconfirmed input..."
**Correct version:** "The replacement transaction only include**s** an unconfirmed input..."

The verb "include" should be in the third person singular form "includes" to agree with the singular subject "transaction."